### PR TITLE
Fixes:

### DIFF
--- a/__load__.zeek
+++ b/__load__.zeek
@@ -1,1 +1,1 @@
-@load os-package-tracking
+@load ./os-package-tracking


### PR DESCRIPTION
fatal error in /usr/local/zeek/host/policies/packages/./zeek-os-package-tracking/__load__.zeek, line 1: can't find os-package-tracking